### PR TITLE
Fix (swap) stride for 1x1 and 3x3, to fit ResNet and ResNeXt specification

### DIFF
--- a/resNeXt.py
+++ b/resNeXt.py
@@ -117,10 +117,9 @@ def split(input_layer, stride):
     # according to Figure 7, they used 64 as # filters for all cifar10 task
 
     with tf.variable_scope('bneck_reduce_size'):
-        conv = conv_bn_relu_layer(input_layer, filter_shape=[1, 1, input_channel, num_filter],
-                                  stride=stride)
+        conv = conv_bn_relu_layer(input_layer, filter_shape=[1, 1, input_channel, num_filter], stride=1)
     with tf.variable_scope('bneck_conv'):
-        conv = conv_bn_relu_layer(conv, filter_shape=[3, 3, num_filter, num_filter], stride=1)
+        conv = conv_bn_relu_layer(conv, filter_shape=[3, 3, num_filter, num_filter], stride=stride)
 
     return conv
 


### PR DESCRIPTION
In ResNet, the stride=2 downsample is realised in the first 1x1 convolution in the bottlenecks. The ResNeXt paper incorporated external [evidence](http://torch.ch/blog/2016/02/04/resnets.html), which stated that applying stride=2 in the 3x3 convolution instead of the 1x1 improves performance *slightly*. This PR makes the implementation compliant with the ResNeXt design choice in that matter.